### PR TITLE
Potential fix for code scanning alert no. 24: Unused import

### DIFF
--- a/src/cronk/cron_to_json.py
+++ b/src/cronk/cron_to_json.py
@@ -1,6 +1,6 @@
 import json
 import re
-from dataclasses import dataclass, field
+
 from typing import Dict, List, Tuple
 
 from loguru import logger


### PR DESCRIPTION
Potential fix for [https://github.com/hlazuroz/cronk-aula/security/code-scanning/24](https://github.com/hlazuroz/cronk-aula/security/code-scanning/24)

To fix the problem, we need to remove the unused imports of `dataclass` and `field` from the `dataclasses` module. This will clean up the code and remove unnecessary dependencies, making the code easier to read and maintain.

- Locate the import statement `from dataclasses import dataclass, field` in the file `src/cronk/cron_to_json.py`.
- Remove the import statement entirely, as neither `dataclass` nor `field` are used in the provided code snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
