### PR TITLE
Potential fix for code scanning alert no. 23: Unused import

### DIFF
--- a/src/cronk/cron_to_json.py
+++ b/src/cronk/cron_to_json.py
@@ -1,4 +1,3 @@
-import json
 import re
 from dataclasses import dataclass, field
 from typing import Dict, List, Tuple


### PR DESCRIPTION
Potential fix for [https://github.com/hlazuroz/cronk-aula/security/code-scanning/23](https://github.com/hlazuroz/cronk-aula/security/code-scanning/23)

To fix the problem, we need to remove the unused import statement for the `json` module. This will clean up the code by eliminating unnecessary dependencies and improving readability.

- Locate the import statement for the `json` module at the beginning of the file.
- Remove the line `import json` from the file.
- Ensure that no other parts of the code rely on this import (which, based on the provided snippet, they do not).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
